### PR TITLE
Update react-tap-event-plugin to 2.0.1

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -28,7 +28,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "react-router-redux": "^4.0.5",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0"
   },


### PR DESCRIPTION
Updating the react tap event plugin to 2.0.1 to fix issue with webpack compiling.